### PR TITLE
TD-217 - Fix for null-pointer exception when using interactive login

### DIFF
--- a/android/src/main/java/nl/recognize/msauthplugin/MsAuthPlugin.java
+++ b/android/src/main/java/nl/recognize/msauthplugin/MsAuthPlugin.java
@@ -137,9 +137,9 @@ public class MsAuthPlugin extends Plugin {
                         TokenResult tokenResult = new TokenResult();
 
                         IAccount account = authenticationResult.getAccount();
+                        tokenResult.setAccessToken(authenticationResult.getAccessToken());
                         tokenResult.setIdToken(account.getIdToken());
-                        tokenResult.setAccessToken(tokenResult.getAccessToken());
-                        tokenResult.setScopes(tokenResult.getScopes());
+                        tokenResult.setScopes(authenticationResult.getScope());
 
                         callback.tokenReceived(tokenResult);
                     }


### PR DESCRIPTION
Fixes #2. Align token result with that of a silent login.