### PR TITLE
Update build.gradle to allow override of MS auth library version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,11 @@ await MsAuthPlugin.logout({
     keyHash: '<Android only, the key hash as obtained above>',
 });
 ```
+## MSAL Versions
+There are some scenarios where the default project may be generated in such a way which prevents a build from succeeding. To get around this, a variable has been exposed to allow users to configure the Microsoft Authentication library version. By setting the `recognizebvMSALVersion` variable in your root `build.gradle` you can override the default version used during dependency resolution. See this [issue](https://github.com/recognizegroup/capacitor-plugin-msauth/issues/42) for more details. Here's an example you can place in your root `build.gradle` file to override the MSAL version.
+
+```groovy
+ext {
+  recognizebvMSALVersion = '5.3.0' // This version fixed the open telemetry issue described in issue #42.
+}
+```

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@ ext {
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.6.1'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.5'
     androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.5.1'
-    msalVersion = project.hasProperty("msalVersion") ? rootProject.ext.msalVersion : '4.9.0'
+    recognizebvMSALVersion = project.hasProperty("recognizebvMSALVersion") ? rootProject.ext.recognizebvMSALVersion : '4.9.0'
 }
 
 buildscript {
@@ -64,7 +64,7 @@ allprojects {
 dependencies {
     implementation project(':capacitor-android')
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
-    implementation "com.microsoft.identity.client:msal:$msalVersion"
+    implementation "com.microsoft.identity.client:msal:$recognizebvMSALVersion"
 
     testImplementation "org.json:json:20230227"
     testImplementation "org.mockito:mockito-inline:5.2.0"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,6 +3,7 @@ ext {
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.6.1'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.5'
     androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.5.1'
+    msalVersion = project.hasProperty("msalVersion") ? rootProject.ext.msalVersion : '4.9.0'
 }
 
 buildscript {
@@ -63,7 +64,7 @@ allprojects {
 dependencies {
     implementation project(':capacitor-android')
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
-    implementation "com.microsoft.identity.client:msal:4.9.0"
+    implementation "com.microsoft.identity.client:msal:$msalVersion"
 
     testImplementation "org.json:json:20230227"
     testImplementation "org.mockito:mockito-inline:5.2.0"


### PR DESCRIPTION
I think this change has the least impact in terms of blast radius, while still allowing for a quick fix. I can also update the docs with a caveat that changing the library version may break the plugin. Let me know what you all think.